### PR TITLE
Update all dependencies to be Tokio 1.0 compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ chrono = "0.4.7"
 derivative = "2.1.1"
 err-derive = "0.2.3"
 futures = "0.3.5"
+futures-intrusive = "0.3.0"
 hex = "0.4.0"
 hmac = "~0.7.1"
 lazy_static = "1.4.0"
@@ -49,8 +50,8 @@ stringprep = "0.1.2"
 strsim = "0.10.0"
 take_mut = "0.2.2"
 time = "0.1.42"
-trust-dns-proto = "0.19.4"
-trust-dns-resolver = "0.19.5"
+trust-dns-proto = "0.20.0"
+trust-dns-resolver = "0.20.0"
 typed-builder = "0.4.0"
 version_check = "0.9.1"
 webpki = "0.21.0"
@@ -65,7 +66,7 @@ version = "0.3.0"
 default-features = false
 
 [dependencies.reqwest]
-version = "0.10.6"
+version = "0.11"
 optional = true
 default-features = false
 features = ["json", "rustls-tls"]


### PR DESCRIPTION
Update `reqwest`, `tokio-dns-proto` and `tokio-dns-resolver` to all use the Tokio 1.0 variants now they have been released.